### PR TITLE
Resolved issue with incorrect compiler path when using wine

### DIFF
--- a/lib/netlinx/compiler.rb
+++ b/lib/netlinx/compiler.rb
@@ -27,7 +27,7 @@ module NetLinx
         user_specified_path,
         'C:\Program Files (x86)\Common Files\AMXShare\COM', # 64-bit O/S path
         'C:\Program Files\Common Files\AMXShare\COM',       # 32-bit O/S path
-        '~/.wine/drive_c/Program\ Files/Common\ Files/AMXShare/COM', # Wine path
+        '~/.wine/drive_c/Program Files/Common Files/AMXShare/COM', # Wine path
       ].compact
       
       # Check for NetLinx compiler.


### PR DESCRIPTION
Removed forward slashes from default wine compiler path as this was causing the File.exists? check to fail, raising a NoCompilerError.