### PR TITLE
Update travis ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: ruby
 rvm:
   - 2.0.0
-  - 2.1.5
+  - 2.1.10
+  - 2.7.1
 script:
   - bundle exec rake ci


### PR DESCRIPTION
Bumping the CI version 2.1.5 to the last revision 2.1.10.
Adding latest ruby version 2.7.1.