### PR TITLE
Validate source file encoding

### DIFF
--- a/lib/netlinx/source_file.rb
+++ b/lib/netlinx/source_file.rb
@@ -18,6 +18,10 @@ module NetLinx
       
       source_code = File.open(@compiler_target_files.first).read
       
+      unless source_code.valid_encoding?
+        source_code.force_encoding Encoding::ASCII_8BIT
+      end
+      
       # Scan file for additional include paths.
       includes = source_code.scan(/(?i)^\s*(?:\#include)\s+'([\w\-]+)'/)
       

--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -11,6 +11,23 @@ describe NetLinx::SourceFile do
   
   include_examples "invokable"
   
+  it "correctly determines encoding for an ASCII file opened as UTF-8" do
+    # Note: This error is caused by setting the option "Use UTF-8 as default
+    # external encoding" when installing Ruby. NetLinx Studio encodes files as
+    # Windows 1252 with invalid UTF-8 bytes in the default file template, which
+    # then causes an encoding issue when Ruby trys to ingest the file as UTF-8.
+    
+    File.should_receive :open do
+      Object.new.tap do |object|
+        object.define_singleton_method :read do
+          "invalid UTF-8 \255"
+        end
+      end
+    end
+    
+    subject = NetLinx::SourceFile.new file: 'anything'
+  end
+  
   it "can auto-discover include files based on #include directives in the source file" do
     file = File.expand_path 'source-file-include.axs', path
     subject = NetLinx::SourceFile.new file: file


### PR DESCRIPTION
For #10

This PR fixes the `invalid byte sequence in UTF-8 (ArgumentError)` message that may appear if Ruby is installed with the `Use UTF-8 as default external encoding` option enabled. This error is due to NetLinx Studio generating a Windows 1252 encoded file with an incompatible UTF-8 encoding, which Ruby then tries to ingest as UTF-8. This PR adds a guard for invalid encoding and forces an invalid UTF-8 string to ASCII encoding when scanning file contents for additional includes. This PR does not affect the source file or the input to the NetLinx compiler (`NLRC.exe`).